### PR TITLE
fix flex grow on home page reviews card

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -73,9 +73,11 @@
   .flex-desktop {
     display: flex;
     gap: 20px;
+    flex-basis: auto;
     .card {
-      width: 40vw;
+      flex-basis: auto;
       margin: 0 auto;
+      flex-grow: 1;
     }
 
     .card-body h5,


### PR DESCRIPTION
<img width="1277" alt="Screenshot 2021-02-04 at 11 50 19" src="https://user-images.githubusercontent.com/35295231/106882542-29cd6980-66df-11eb-81f3-e28ee9a65e4b.png">
align the cards in flex to take the same amount of space